### PR TITLE
feat(ci): introduce automatic rebasing for PRs

### DIFF
--- a/.github/workflows/rebase-pull-requests.yml
+++ b/.github/workflows/rebase-pull-requests.yml
@@ -1,0 +1,17 @@
+name: Rebase
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  rebase:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: peter-evans/rebase@v3
+        with:
+          base: main


### PR DESCRIPTION
When PR is merged, all other PRs automatically receives that commit.

Warning: This is up for discussion. I use it in many projects, but since
it's your environment, review this carefully if it's going to be
convenient to you.

The problem with that CI is that you need to know how to work with git
in order to use it. On one hand it rebases all PRs automatically and
therefore we avoid some issues. On the other hand rebase basically does
`git push -f` from GitHub actions into your branch.

So you need to understand when pushing from your local branch to the
remote when you should rebase onto remote branch, or when you should
just do force-push instead.

With some time, you get used to that, but yeah it needs some time to get
familiar with it.
