### PR TITLE
Fix dialog rendering issues

### DIFF
--- a/src/app/blocking-qr/dialog.tsx
+++ b/src/app/blocking-qr/dialog.tsx
@@ -12,6 +12,7 @@ import {
 import {Field, FieldError, FieldLabel} from '@/components/ui/field';
 import {useTranslations} from 'use-intl';
 import {Button} from '@/components/ui/button';
+import {StyledDialogWrapper} from '@/components/styled-dialog-wrapper';
 
 export interface BlockingQRController {
     shouldBlock: boolean;
@@ -85,68 +86,60 @@ export function BlockingQR({
         }
     }
     return (
-        <Dialog.Root open={true}>
-            <Dialog.Portal>
-                <Dialog.Overlay className="fixed inset-0 bg-black/50 backdrop-blur-sm" />
-                <Dialog.Content
+        <StyledDialogWrapper
+            open={true}
+            preventDefault={true}
+            contentClassName="-translate-y-1/2 p-4"
+        >
+            <>
+                <div className="w-full flex justify-center mb-4">
+                    <HatGlasses className="size-20 rounded-full bg-white dark:bg-zinc-900 p-4" />
+                </div>
+                <div
                     className="
-                    fixed left-1/2 top-1/2
-                    -translate-x-1/2 -translate-y-1/2
-
-                    w-full max-w-lg p-4
-                    max-h-dvh overflow-y-scroll
-                    "
-                    onInteractOutside={e => e.preventDefault()}
-                >
-                    <div className="w-full flex justify-center mb-4">
-                        <HatGlasses className="size-20 rounded-full bg-white dark:bg-zinc-900 p-4" />
-                    </div>
-                    <div
-                        className="
                         rounded-xl bg-white dark:bg-zinc-900
                         shadow-xl
                         py-4 px-6 space-y-4
                         w-full flex flex-col items-center
                         mb-20
                         "
-                    >
-                        <Dialog.Title className="w-full text-md font-semibold text-center">
-                            {t('title')}
-                        </Dialog.Title>
-                        <Field>
-                            <FieldLabel
-                                htmlFor="link"
-                                className="font-normal text-center"
-                            >
-                                {t('description')}
-                            </FieldLabel>
-                            <InputGroup>
-                                <InputGroupInput
-                                    id="link"
-                                    placeholder={t('link-placeholder')}
-                                    type="text"
-                                    value={link}
-                                    onChange={e => setLink(e.target.value)}
-                                />
-                                <InputGroupAddon>
-                                    <Link />
-                                </InputGroupAddon>
-                            </InputGroup>
-                            <FieldError>{linkError}</FieldError>
-                        </Field>
-                        <Button
-                            className="cursor-pointer w-30"
-                            variant="secondary"
-                            onClick={() => void onJoin()}
-                            disabled={loading}
+                >
+                    <Dialog.Title className="w-full text-md font-semibold text-center">
+                        {t('title')}
+                    </Dialog.Title>
+                    <Field>
+                        <FieldLabel
+                            htmlFor="link"
+                            className="font-normal text-center"
                         >
-                            {!loading && t('join')}
-                            {loading && <Spinner />}
-                        </Button>
-                    </div>
-                </Dialog.Content>
-            </Dialog.Portal>
-        </Dialog.Root>
+                            {t('description')}
+                        </FieldLabel>
+                        <InputGroup>
+                            <InputGroupInput
+                                id="link"
+                                placeholder={t('link-placeholder')}
+                                type="text"
+                                value={link}
+                                onChange={e => setLink(e.target.value)}
+                            />
+                            <InputGroupAddon>
+                                <Link />
+                            </InputGroupAddon>
+                        </InputGroup>
+                        <FieldError>{linkError}</FieldError>
+                    </Field>
+                    <Button
+                        className="cursor-pointer w-30"
+                        variant="secondary"
+                        onClick={() => void onJoin()}
+                        disabled={loading}
+                    >
+                        {!loading && t('join')}
+                        {loading && <Spinner />}
+                    </Button>
+                </div>
+            </>
+        </StyledDialogWrapper>
     );
 }
 

--- a/src/app/blocking-qr/dialog.tsx
+++ b/src/app/blocking-qr/dialog.tsx
@@ -129,7 +129,7 @@ export function BlockingQR({
                         <FieldError>{linkError}</FieldError>
                     </Field>
                     <Button
-                        className="cursor-pointer w-30"
+                        className="cursor-pointer min-w-38"
                         variant="secondary"
                         onClick={() => void onJoin()}
                         disabled={loading}

--- a/src/app/edit/dialog.tsx
+++ b/src/app/edit/dialog.tsx
@@ -20,6 +20,7 @@ import {Field, FieldError, FieldGroup, FieldLabel} from '@/components/ui/field';
 import {ReactNode, useState} from 'react';
 import {useTranslations} from 'use-intl';
 import {Button} from '@/components/ui/button';
+import {StyledDialogWrapper} from '@/components/styled-dialog-wrapper';
 
 interface EditProfileProps {
     open: boolean;
@@ -31,22 +32,13 @@ interface EditProfileProps {
 export function EditProfileDialog(props: EditProfileProps): ReactNode {
     const {open, setOpen} = props;
     return (
-        <Dialog.Root open={open} onOpenChange={setOpen}>
-            <Dialog.Portal>
-                <Dialog.Overlay className="fixed inset-0 bg-black/50 backdrop-blur-sm" />
-                <Dialog.Content
-                    className="
-                    fixed left-1/2 top-1/2
-                    -translate-x-1/2 -translate-y-1/2
-
-                    w-full max-w-lg p-5
-                    max-h-dvh overflow-y-scroll
-                    "
-                >
-                    <EditProfileDialogContent {...props} />
-                </Dialog.Content>
-            </Dialog.Portal>
-        </Dialog.Root>
+        <StyledDialogWrapper
+            open={open}
+            onOpenChange={setOpen}
+            contentClassName="p-5"
+        >
+            <EditProfileDialogContent {...props} />
+        </StyledDialogWrapper>
     );
 }
 
@@ -378,68 +370,56 @@ function EmailInput({
                 </InputGroupAddon>
             </InputGroup>
             <FieldError>{emailError}</FieldError>
-            <Dialog.Root open={openUnlink} onOpenChange={setOpenUnlink}>
-                <Dialog.Portal>
-                    <Dialog.Overlay className="fixed inset-0 bg-black/50 backdrop-blur-sm" />
-                    <Dialog.Content
-                        className="
-                    fixed left-1/2 top-1/2
-                    -translate-x-1/2 -translate-y-1/2
-
-                    w-full max-w-lg p-5
-                    max-h-dvh overflow-y-scroll
-                    "
-                    >
-                        <div
-                            className="
+            <StyledDialogWrapper
+                open={openUnlink}
+                onOpenChange={setOpenUnlink}
+                contentClassName="-translate-y-1/2 p-5"
+            >
+                <div
+                    className="
                         rounded-xl bg-white dark:bg-zinc-900
                         shadow-xl
                         "
-                        >
-                            <div className="relative flex items-center mt-1 mx-1">
-                                <Dialog.Title className="w-full text-md font-semibold text-center pt-2">
-                                    {t('email-unlink-sure')}
-                                </Dialog.Title>
+                >
+                    <div className="relative flex items-center mt-1 mx-1">
+                        <Dialog.Title className="w-full text-md font-semibold text-center pt-2">
+                            {t('email-unlink-sure')}
+                        </Dialog.Title>
 
-                                <Dialog.Close
-                                    className="absolute right-0 top-0"
-                                    asChild
-                                >
-                                    <Button
-                                        variant="ghost"
-                                        className="cursor-pointer"
-                                    >
-                                        <X />
-                                    </Button>
-                                </Dialog.Close>
-                            </div>
-                            <div className="p-4 space-y-4 flex flex-col items-center">
-                                <p className="text-center">
-                                    {t('email-unlink-sure-verbose')}
-                                </p>
-                                <div className="flex gap-2 items-end">
-                                    <Button
-                                        className="cursor-pointer"
-                                        variant="outline"
-                                        onClick={() => setOpenUnlink(false)}
-                                        disabled={loading}
-                                    >
-                                        {t('cancel')}
-                                    </Button>
-                                    <Button
-                                        className="cursor-pointer"
-                                        onClick={() => void onUnlink()}
-                                        disabled={loading}
-                                    >
-                                        {!loading && t('continue')}
-                                        {loading && <Spinner />}
-                                    </Button>
-                                </div>
-                            </div>
+                        <Dialog.Close
+                            className="absolute right-0 top-0"
+                            asChild
+                        >
+                            <Button variant="ghost" className="cursor-pointer">
+                                <X />
+                            </Button>
+                        </Dialog.Close>
+                    </div>
+                    <div className="p-4 space-y-4 flex flex-col items-center">
+                        <p className="text-center">
+                            {t('email-unlink-sure-verbose')}
+                        </p>
+                        <div className="flex gap-2 items-end">
+                            <Button
+                                className="cursor-pointer"
+                                variant="outline"
+                                onClick={() => setOpenUnlink(false)}
+                                disabled={loading}
+                            >
+                                {t('cancel')}
+                            </Button>
+                            <Button
+                                className="cursor-pointer"
+                                onClick={() => void onUnlink()}
+                                disabled={loading}
+                            >
+                                {!loading && t('continue')}
+                                {loading && <Spinner />}
+                            </Button>
                         </div>
-                    </Dialog.Content>
-                </Dialog.Portal>
-            </Dialog.Root>
+                    </div>
+                </div>
+            </StyledDialogWrapper>
         </Field>
     );
 }

--- a/src/app/edit/dialog.tsx
+++ b/src/app/edit/dialog.tsx
@@ -35,7 +35,7 @@ export function EditProfileDialog(props: EditProfileProps): ReactNode {
         <StyledDialogWrapper
             open={open}
             onOpenChange={setOpen}
-            contentClassName="p-5"
+            contentClassName="-translate-y-1/2 p-5"
         >
             <EditProfileDialogContent {...props} />
         </StyledDialogWrapper>

--- a/src/app/edit/email-dialog.tsx
+++ b/src/app/edit/email-dialog.tsx
@@ -14,6 +14,7 @@ import {
     InputOTPSlot,
     InputOTPSeparator,
 } from '@/components/ui/input-otp';
+import {StyledDialogWrapper} from '@/components/styled-dialog-wrapper';
 
 export interface EmailDialogProps {
     email: string;
@@ -24,22 +25,13 @@ export interface EmailDialogProps {
 export function EmailDialog(props: EmailDialogProps): ReactNode {
     const {open, setOpen} = props;
     return (
-        <Dialog.Root open={open} onOpenChange={setOpen}>
-            <Dialog.Portal>
-                <Dialog.Overlay className="fixed inset-0 bg-black/50 backdrop-blur-sm" />
-                <Dialog.Content
-                    className="
-                    fixed left-1/2 top-1/2
-                    -translate-x-1/2 -translate-y-1/2
-
-                    w-full max-w-lg p-5
-                    max-h-dvh overflow-y-scroll
-                    "
-                >
-                    <EmailDialogContent {...props} />
-                </Dialog.Content>
-            </Dialog.Portal>
-        </Dialog.Root>
+        <StyledDialogWrapper
+            open={open}
+            onOpenChange={setOpen}
+            contentClassName="-translate-y-1/2 p-5"
+        >
+            <EmailDialogContent {...props} />
+        </StyledDialogWrapper>
     );
 }
 

--- a/src/app/friends/all-friends-list.tsx
+++ b/src/app/friends/all-friends-list.tsx
@@ -7,6 +7,7 @@ import {AvatarImage, AvatarFallback, Avatar} from '@/components/ui/avatar';
 import {createFileLink} from '@/lib/utils';
 import {Dialog} from 'radix-ui';
 import {useUserAccessHashes} from '@/components/useraccesshashes-provider';
+import {StyledDialogWrapper} from '@/components/styled-dialog-wrapper';
 
 interface AllFriendsListProps {
     friends: UserDetails[];
@@ -58,59 +59,48 @@ export function AllFriendsList({friends, open, setOpen}: AllFriendsListProps) {
     };
 
     return (
-        <Dialog.Root open={open} onOpenChange={setOpen}>
-            <Dialog.Portal>
-                <Dialog.Overlay className="fixed inset-0 bg-black/50 backdrop-blur-sm" />
-                <Dialog.Content
-                    className="
-                    fixed left-1/2 top-1/2
-                    -translate-x-1/2 -translate-y-1/2
-
-                    w-full max-w-lg p-5
-                    max-h-dvh overflow-y-scroll
-                    "
-                >
-                    <div
-                        className="
+        <StyledDialogWrapper
+            open={open}
+            onOpenChange={setOpen}
+            contentClassName="-translate-y-1/2 p-5"
+        >
+            <div
+                className="
                             rounded-xl bg-white dark:bg-zinc-900
                             shadow-xl
                             "
-                    >
-                        <div className="p-0">
-                            <div className="flex flex-col">
-                                <div className="relative flex items-center mt-1 mx-1">
-                                    <Dialog.Title className="w-full text-md font-semibold text-center pt-2">
-                                        {t('friends.see_all')}
-                                    </Dialog.Title>
-                                    <Dialog.Close
-                                        className="absolute right-0 top-0"
-                                        asChild
-                                    >
-                                        <Button
-                                            variant="ghost"
-                                            className="cursor-pointer"
-                                        >
-                                            <X />
-                                        </Button>
-                                    </Dialog.Close>
-                                </div>
+            >
+                <div className="p-0">
+                    <div className="flex flex-col">
+                        <div className="relative flex items-center mt-1 mx-1">
+                            <Dialog.Title className="w-full text-md font-semibold text-center pt-2">
+                                {t('friends.see_all')}
+                            </Dialog.Title>
+                            <Dialog.Close
+                                className="absolute right-0 top-0"
+                                asChild
+                            >
+                                <Button
+                                    variant="ghost"
+                                    className="cursor-pointer"
+                                >
+                                    <X />
+                                </Button>
+                            </Dialog.Close>
+                        </div>
 
-                                <div className="flex flex-col gap-4">
-                                    {friends.map(friend => (
-                                        <FriendListItem
-                                            id={friend.id.toString()}
-                                            friend={friend}
-                                            onClick={() =>
-                                                void openFriendPage(friend)
-                                            }
-                                        />
-                                    ))}
-                                </div>
-                            </div>
+                        <div className="flex flex-col gap-4">
+                            {friends.map(friend => (
+                                <FriendListItem
+                                    id={friend.id.toString()}
+                                    friend={friend}
+                                    onClick={() => void openFriendPage(friend)}
+                                />
+                            ))}
                         </div>
                     </div>
-                </Dialog.Content>
-            </Dialog.Portal>
-        </Dialog.Root>
+                </div>
+            </div>
+        </StyledDialogWrapper>
     );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -37,6 +37,7 @@ import {EditProfileDialog} from '@/app/edit/dialog';
 import * as Dialog from '@radix-ui/react-dialog';
 import {ProfileDescription} from '@/components/profile-description';
 import {FriendsBlock} from './friends/friends-block';
+import {StyledDialogWrapper} from '@/components/styled-dialog-wrapper';
 
 type SwipeDirection = 'left' | 'right';
 
@@ -242,27 +243,24 @@ function FeedReviewDeck({
                 })}
             </div>
 
-            <Dialog.Root open={isDialogOpen} onOpenChange={setIsDialogOpen}>
-                <Dialog.Portal>
-                    <Dialog.Overlay className="fixed inset-0 bg-black/50 backdrop-blur-sm" />
-                    <Dialog.Content className="fixed left-1/2 top-0 bottom-0 lg:top-4 lg:bottom-4 w-full lg:rounded-2xl max-w-md -translate-x-1/2 overflow-y-auto bg-white dark:bg-zinc-950">
-                        {selectedCard && (
-                            <FeedDialogContent
-                                selectedCard={selectedCard}
-                                isAnimating={isAnimating}
-                                closeDialog={() => {
-                                    setIsDialogOpen(false);
-                                    setSelectedCard(null);
-                                }}
-                                isBusy={isBusy}
-                                handleReview={direction =>
-                                    void handleReview(direction)
-                                }
-                            />
-                        )}
-                    </Dialog.Content>
-                </Dialog.Portal>
-            </Dialog.Root>
+            <StyledDialogWrapper
+                open={isDialogOpen}
+                onOpenChange={setIsDialogOpen}
+                contentClassName="top-0 bottom-0 lg:top-4 lg:bottom-4 lg:rounded-2xl max-w-md max-h-none -translate-x-1/2 -translate-y-0 bg-white dark:bg-zinc-950"
+            >
+                {selectedCard && (
+                    <FeedDialogContent
+                        selectedCard={selectedCard}
+                        isAnimating={isAnimating}
+                        closeDialog={() => {
+                            setIsDialogOpen(false);
+                            setSelectedCard(null);
+                        }}
+                        isBusy={isBusy}
+                        handleReview={direction => void handleReview(direction)}
+                    />
+                )}
+            </StyledDialogWrapper>
             <SuggestEmailBindingDialog
                 status={emailSuggestionStatus}
                 setStatus={setEmailSuggestionStatus}
@@ -452,35 +450,31 @@ function SuggestEmailBindingDialog({
 }: SuggestEmailBindingDialogProps) {
     const t = useTranslations('profile.feed');
     return (
-        <Dialog.Root
+        <StyledDialogWrapper
             open={status === 'suggested'}
             onOpenChange={() => setStatus('pending')}
+            contentClassName="-translate-y-1/2 w-fit max-w-sm max-h-none rounded-2xl p-6 bg-white dark:bg-zinc-950 shadow-lg"
         >
-            <Dialog.Portal>
-                <Dialog.Overlay className="fixed inset-0 bg-black/50 backdrop-blur-sm" />
-                <Dialog.Content className="fixed left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 w-fit max-w-sm rounded-2xl p-6 bg-white dark:bg-zinc-950 shadow-lg">
-                    <>
-                        <h2 className="text-center">
-                            {t('email_binding.description')}
-                        </h2>
-                        <div className="w-full flex flex-row grow-1 gap-2 mt-4">
-                            <Button
-                                className="grow-1"
-                                onClick={() => setStatus('declined')}
-                            >
-                                {t('email_binding.decline')}
-                            </Button>
-                            <Button
-                                className="grow-2"
-                                onClick={() => setStatus('accepted')}
-                            >
-                                {t('email_binding.confirm')}
-                            </Button>
-                        </div>
-                    </>
-                </Dialog.Content>
-            </Dialog.Portal>
-        </Dialog.Root>
+            <>
+                <h2 className="text-center">
+                    {t('email_binding.description')}
+                </h2>
+                <div className="w-full flex flex-row grow-1 gap-2 mt-4">
+                    <Button
+                        className="grow-1"
+                        onClick={() => setStatus('declined')}
+                    >
+                        {t('email_binding.decline')}
+                    </Button>
+                    <Button
+                        className="grow-2"
+                        onClick={() => setStatus('accepted')}
+                    >
+                        {t('email_binding.confirm')}
+                    </Button>
+                </div>
+            </>
+        </StyledDialogWrapper>
     );
 }
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -396,7 +396,7 @@ function FeedDialogContent({
                     </div>
                 </div>
 
-                <div className="flex flex-col flex-1 shrink p-6 overflow-y-auto pb-12 relative">
+                <div className="flex flex-col flex-1 shrink p-6 pb-12 relative">
                     <h3 className="text-2xl font-semibold text-zinc-950 dark:text-zinc-50 mb-2">
                         {selectedCard.details.nickname}
                     </h3>

--- a/src/app/redirect/[deeplink]/page.tsx
+++ b/src/app/redirect/[deeplink]/page.tsx
@@ -8,6 +8,7 @@ import {Spinner} from '@/components/ui/spinner';
 import {useEffect, useState, ReactNode} from 'react';
 import {useSession} from '@/components/session-provider';
 import {useBlockingQR} from '@/app/blocking-qr/dialog';
+import {StyledDialogWrapper} from '@/components/styled-dialog-wrapper';
 
 type State = 'loading' | 'friend-token-expired';
 
@@ -76,42 +77,32 @@ export default function DeeplinkPage(): ReactNode {
 function FriendTokenExpired() {
     const t = useTranslations('redirect.friend-token-expired');
     return (
-        <Dialog.Root open={true}>
-            <Dialog.Portal>
-                <Dialog.Overlay className="fixed inset-0 bg-black/50 backdrop-blur-sm" />
-                <Dialog.Content
-                    className="
-                fixed left-1/2 top-1/2
-                -translate-x-1/2 -translate-y-1/2
-
-                w-full max-w-lg p-4
-                max-h-dvh overflow-y-scroll
-                "
-                    onInteractOutside={e => e.preventDefault()}
-                >
-                    <div className="w-full flex justify-center mb-4">
-                        <div className="rounded-full bg-white dark:bg-zinc-900 p-3">
-                            <Link2Off className="size-5" />
-                        </div>
+        <StyledDialogWrapper
+            open={true}
+            preventDefault={true}
+            contentClassName="-translate-y-1/2 p-4"
+        >
+            <>
+                <div className="w-full flex justify-center mb-4">
+                    <div className="rounded-full bg-white dark:bg-zinc-900 p-3">
+                        <Link2Off className="size-5" />
                     </div>
-                    <div
-                        className="
+                </div>
+                <div
+                    className="
                     rounded-xl bg-white dark:bg-zinc-900
                     shadow-xl
                     py-4 px-6 space-y-4
                     w-full flex flex-col items-center
                     mb-20
                     "
-                    >
-                        <Dialog.Title className="w-full text-md font-semibold text-center">
-                            {t('title')}
-                        </Dialog.Title>
-                        <p className="text-md text-center">
-                            {t('description')}
-                        </p>
-                    </div>
-                </Dialog.Content>
-            </Dialog.Portal>
-        </Dialog.Root>
+                >
+                    <Dialog.Title className="w-full text-md font-semibold text-center">
+                        {t('title')}
+                    </Dialog.Title>
+                    <p className="text-md text-center">{t('description')}</p>
+                </div>
+            </>
+        </StyledDialogWrapper>
     );
 }

--- a/src/app/sign-in/code.tsx
+++ b/src/app/sign-in/code.tsx
@@ -17,6 +17,7 @@ import {
 } from '@/components/ui/input-otp';
 import {useNavigate} from 'react-router';
 import * as Notifications from '@/notifications';
+import {StyledDialogWrapper} from '@/components/styled-dialog-wrapper';
 
 export interface CodeDialogProps {
     email: string;
@@ -27,22 +28,13 @@ export interface CodeDialogProps {
 export function CodeDialog(props: CodeDialogProps): ReactNode {
     const {open, setOpen} = props;
     return (
-        <Dialog.Root open={open} onOpenChange={setOpen}>
-            <Dialog.Portal>
-                <Dialog.Overlay className="fixed inset-0 bg-black/50 backdrop-blur-sm" />
-                <Dialog.Content
-                    className="
-                    fixed left-1/2 top-1/2
-                    -translate-x-1/2 -translate-y-1/2
-
-                    w-full max-w-lg p-5
-                    max-h-dvh overflow-y-scroll
-                    "
-                >
-                    <CodeDialogContent {...props} />
-                </Dialog.Content>
-            </Dialog.Portal>
-        </Dialog.Root>
+        <StyledDialogWrapper
+            open={open}
+            onOpenChange={setOpen}
+            contentClassName="-translate-y-1/2 p-5"
+        >
+            <CodeDialogContent {...props} />
+        </StyledDialogWrapper>
     );
 }
 

--- a/src/components/adjuster.tsx
+++ b/src/components/adjuster.tsx
@@ -15,6 +15,7 @@ import {
 } from 'react';
 import {useTranslations} from 'use-intl';
 import {Button} from '@/components/ui/button';
+import {StyledDialogWrapper} from './styled-dialog-wrapper';
 
 export type AdjusterPayload =
     | {
@@ -39,35 +40,28 @@ export function Adjuster({
     const open = useMemo(() => payload.type === 'open', [payload]);
 
     return (
-        <Dialog.Root open={open} onOpenChange={setOpen}>
-            <Dialog.Portal>
-                <Dialog.Overlay className="fixed inset-0 bg-black/50 backdrop-blur-sm" />
-                <Dialog.Content
+        <StyledDialogWrapper
+            open={open}
+            onOpenChange={setOpen}
+            contentClassName="-translate-y-1/2 p-5"
+        >
+            <>
+                <div
                     className="
-                    fixed left-1/2 top-1/2
-                    -translate-x-1/2 -translate-y-1/2
-
-                    w-full max-w-lg p-5
-                    max-h-dvh overflow-y-auto
-                    "
-                >
-                    <div
-                        className="
                         rounded-xl bg-white dark:bg-zinc-900
                         shadow-xl
                         "
-                    >
-                        {payload.type === 'open' && (
-                            <AdjusterContent
-                                payload={payload}
-                                setOpen={setOpen}
-                                onAdjusted={onAdjusted}
-                            />
-                        )}
-                    </div>
-                </Dialog.Content>
-            </Dialog.Portal>
-        </Dialog.Root>
+                >
+                    {payload.type === 'open' && (
+                        <AdjusterContent
+                            payload={payload}
+                            setOpen={setOpen}
+                            onAdjusted={onAdjusted}
+                        />
+                    )}
+                </div>
+            </>
+        </StyledDialogWrapper>
     );
 }
 

--- a/src/components/styled-dialog-wrapper.tsx
+++ b/src/components/styled-dialog-wrapper.tsx
@@ -1,0 +1,38 @@
+import * as Dialog from '@radix-ui/react-dialog';
+import {ReactNode} from 'react';
+import {cn} from '@/lib/utils';
+
+interface StyledDialogWrapperProps {
+    open: boolean;
+    onOpenChange?: (open: boolean) => void;
+    preventDefault?: boolean;
+    contentClassName?: string;
+    children: ReactNode;
+}
+
+export function StyledDialogWrapper({
+    open,
+    onOpenChange,
+    preventDefault = false,
+    contentClassName,
+    children,
+}: StyledDialogWrapperProps) {
+    return (
+        <Dialog.Root open={open} onOpenChange={onOpenChange}>
+            <Dialog.Portal>
+                <Dialog.Overlay className="fixed inset-0 bg-black/50 backdrop-blur-sm" />
+                <Dialog.Content
+                    {...(preventDefault && {
+                        onInteractOutside: e => e.preventDefault(),
+                    })}
+                    className={cn(
+                        'fixed left-1/2 top-1/2 -translate-x-1/2 w-full max-w-lg max-h-dvh overflow-y-auto',
+                        contentClassName,
+                    )}
+                >
+                    {children}
+                </Dialog.Content>
+            </Dialog.Portal>
+        </Dialog.Root>
+    );
+}


### PR DESCRIPTION
Closes #185, closes #189


Blocking qr dialog now does not have a scrollbar (as well as other dialogs where it was redundant), horizontal padding for the "join" button was fixed:
<img width="622" height="463" alt="image" src="https://github.com/user-attachments/assets/e292dd0f-32d1-4ac3-b024-fd489962a6b9" />


The entire feed dialog is now scrollable:
<img width="471" height="800" alt="CleanShot 2026-06-07 at 01 53 38" src="https://github.com/user-attachments/assets/b19ea1cd-49eb-4cb6-b5d8-f8073775f0e5" />
