### PR TITLE
fix: update app context with pfp on save

### DIFF
--- a/src/app/edit/dialog.tsx
+++ b/src/app/edit/dialog.tsx
@@ -116,7 +116,7 @@ function EditProfileDialogContent({setOpen}: EditProfileProps): ReactNode {
         setLoading(false);
         if (result.ok) {
             setOpen(false);
-            app.setUserDetails({...userDetails, ...validated});
+            app.setUserDetails({...userDetails, ...validated, avatar});
         } else {
             toast.error(t('error-connection'));
         }


### PR DESCRIPTION
The profile picture wasn't being added to app context after saving changes to the profile.

Fixes #266