### PR TITLE
fix(network): preserve cached data on transient network errors

### DIFF
--- a/src/app/community/page.tsx
+++ b/src/app/community/page.tsx
@@ -1,6 +1,8 @@
 import {useBackend} from '@/backend.context';
 import {Button} from '@/components/ui/button';
 import {
+    InfiniteData,
+    QueryKey,
     useInfiniteQuery,
     useMutation,
     useQuery,
@@ -9,12 +11,19 @@ import {
 import {Loader2, MessageCircle, AlertCircle, Clock} from 'lucide-react';
 import {useTranslations} from 'use-intl';
 import {useState, useCallback, useMemo} from 'react';
-import {CommunityPost} from '@/network/friendly-client';
+import {
+    CommunityPost,
+    ListCommunityPostsResponse,
+} from '@/network/friendly-client';
 import {toast} from 'sonner';
 import {StyledAvatar} from '@/components/styled-avatar';
 import {createFileLink} from '@/lib/utils';
 import {MarkdownArea} from '@/components/ui/markdown-area';
 import {Textarea} from '@/components/ui/textarea';
+import {unwrap} from '@/network/result';
+import {NetworkError} from '@/network/errors';
+import {UserDetails} from '@/types/user-details';
+import {formatNetworkError} from '@/services/backend-service';
 
 export function CommunityPage() {
     const t = useTranslations('community');
@@ -22,14 +31,17 @@ export function CommunityPage() {
     const queryClient = useQueryClient();
     const [newPostText, setNewPostText] = useState('');
 
-    const postsQuery = useInfiniteQuery({
+    const postsQuery = useInfiniteQuery<
+        ListCommunityPostsResponse,
+        NetworkError,
+        InfiniteData<ListCommunityPostsResponse, string | null>,
+        QueryKey,
+        string | null
+    >({
         queryKey: ['communityPosts'],
-        queryFn: ({pageParam}) => backend.listPosts(pageParam),
-        initialPageParam: null as string | null,
-        getNextPageParam: lastPage =>
-            lastPage.ok && lastPage.data.nextId !== null
-                ? lastPage.data.nextId
-                : undefined,
+        queryFn: ({pageParam}) => backend.listPosts(pageParam).then(unwrap),
+        initialPageParam: null,
+        getNextPageParam: lastPage => lastPage.nextId ?? undefined,
     });
 
     const loadMore = () => {
@@ -70,6 +82,8 @@ export function CommunityPage() {
         await createPostMutation.mutateAsync(newPostText);
     }, [newPostText, createPostMutation]);
 
+    const isLoadingError = postsQuery.isError && postsQuery.data === undefined;
+
     let content;
 
     if (postsQuery.isLoading) {
@@ -78,12 +92,14 @@ export function CommunityPage() {
                 <Loader2 className="h-10 w-10 animate-spin text-muted-foreground" />
             </div>
         );
-    } else if (postsQuery.isError) {
+    } else if (isLoadingError) {
         content = (
             <div className="flex flex-col h-[50vh] gap-4 w-full items-center justify-center">
                 <AlertCircle className="h-10 w-10 animate-pulse text-foreground/80" />
                 <h3 className="text-center">
-                    {postsQuery.error?.message ?? t('unknown_error')}
+                    {postsQuery.error
+                        ? formatNetworkError(postsQuery.error)
+                        : t('unknown_error')}
                 </h3>
                 <Button
                     variant="outline"
@@ -96,23 +112,9 @@ export function CommunityPage() {
         );
     } else {
         const pages = postsQuery.data?.pages ?? [];
-        const posts = pages.flatMap(p => (p.ok ? p.data.data : []));
+        const posts = pages.flatMap(p => p.data);
 
-        if (posts.length === 0 && pages.length > 0 && !pages[0].ok) {
-            content = (
-                <div className="flex flex-col h-[50vh] gap-4 w-full items-center justify-center">
-                    <AlertCircle className="h-10 w-10 animate-pulse text-foreground/80" />
-                    <h3 className="text-center">{t('unknown_error')}</h3>
-                    <Button
-                        variant="outline"
-                        className="mt-2"
-                        onClick={() => void postsQuery.refetch()}
-                    >
-                        {t('retry')}
-                    </Button>
-                </div>
-            );
-        } else if (posts.length === 0) {
+        if (posts.length === 0) {
             content = (
                 <div className="flex flex-col h-[50vh] gap-4 w-full items-center justify-center px-6 text-center">
                     <MessageCircle className="w-12 h-12 text-muted-foreground" />
@@ -181,17 +183,15 @@ function CreatePostCard({
 }: CreatePostCardProps) {
     const t = useTranslations('community');
     const backend = useBackend();
-    const userQuery = useQuery({
+    const userQuery = useQuery<UserDetails, NetworkError>({
         queryKey: ['userDetails'],
-        queryFn: () => backend.getUserDetails(),
+        queryFn: () => backend.getUserDetails().then(unwrap),
     });
 
     const avatarUrl = useMemo(
         () =>
-            userQuery.data?.ok && userQuery.data?.data?.avatar
-                ? createFileLink(userQuery.data.data.avatar)
-                : '',
-        [userQuery],
+            userQuery.data?.avatar ? createFileLink(userQuery.data.avatar) : '',
+        [userQuery.data],
     );
 
     return (
@@ -200,11 +200,7 @@ function CreatePostCard({
                 <StyledAvatar
                     avatarClassName="w-10 h-10"
                     src={avatarUrl}
-                    nickname={
-                        userQuery?.data?.ok
-                            ? userQuery?.data?.data?.nickname
-                            : ''
-                    }
+                    nickname={userQuery.data?.nickname ?? ''}
                 />
                 <div className="w-full flex-1 flex flex-col gap-2 min-w-0">
                     <Textarea

--- a/src/app/feed/page.tsx
+++ b/src/app/feed/page.tsx
@@ -1,7 +1,7 @@
 import {useAppContext} from '@/app.context';
 import {Button} from '@/components/ui/button';
 import {useEmailBindingSuggestion} from '@/lib/email-binding-suggestion';
-import {FeedItem} from '@/network/friendly-client';
+import {FeedItem, FeedQueueResponse} from '@/network/friendly-client';
 import {Activity, BookUser, Loader2} from 'lucide-react';
 import {useCallback, useEffect, useState} from 'react';
 import {useTranslations} from 'use-intl';
@@ -13,6 +13,8 @@ import {useQuery} from '@tanstack/react-query';
 import {formatNetworkError} from '@/services/backend-service';
 import {toast} from 'sonner';
 import {cn} from '@/lib/utils';
+import {unwrap} from '@/network/result';
+import {NetworkError} from '@/network/errors';
 
 export type SwipeDirection = 'left' | 'right';
 
@@ -41,9 +43,9 @@ export default function FeedPage() {
 
     const backend = useBackend();
 
-    const feedQuery = useQuery({
+    const feedQuery = useQuery<FeedQueueResponse, NetworkError>({
         queryKey: ['feedQueue'],
-        queryFn: () => backend.getFeedQueue(),
+        queryFn: () => backend.getFeedQueue().then(unwrap),
     });
 
     const [cards, setCards] = useState<FeedItem[]>([]);
@@ -60,19 +62,20 @@ export default function FeedPage() {
     } = useEmailBindingSuggestion(app.userDetails?.email ?? null);
 
     useEffect(() => {
-        if (!feedQuery.data?.ok) {
+        if (!feedQuery.data) {
             return;
         }
 
-        setCards(feedQuery.data.data.entries);
-        if (feedQuery.data.data.entries.length > 0)
-            setSelectedCard(feedQuery.data.data.entries[0]);
+        setCards(feedQuery.data.entries);
+        if (feedQuery.data.entries.length > 0)
+            setSelectedCard(feedQuery.data.entries[0]);
     }, [feedQuery.data]);
 
-    const feedErrorMessage =
-        feedQuery.data && !feedQuery.data.ok
-            ? formatNetworkError(feedQuery.data.error)
-            : null;
+    const feedErrorMessage = feedQuery.error
+        ? formatNetworkError(feedQuery.error)
+        : null;
+
+    const isLoadingError = feedQuery.isError && feedQuery.data === undefined;
 
     const onReview = useCallback(
         async (card: FeedItem, direction: SwipeDirection) => {
@@ -138,7 +141,7 @@ export default function FeedPage() {
         );
     }
 
-    if (feedQuery.isError) {
+    if (isLoadingError) {
         return (
             <div className="flex h-full flex-col items-center justify-center rounded-xl border border-destructive/30 bg-card px-6 text-center">
                 <Activity className="h-8 w-8 text-destructive" />

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -10,6 +10,10 @@ import {useBackend} from '@/backend.context';
 import {formatNetworkError} from '@/services/backend-service';
 import {createFileLink} from '@/lib/utils';
 import {useQuery, useQueryClient} from '@tanstack/react-query';
+import {unwrap} from '@/network/result';
+import {NetworkError} from '@/network/errors';
+import {UserDetails} from '@/types/user-details';
+import {NetworkDetailsResponse} from '@/network/friendly-client';
 import {useSession} from '@/components/session-provider';
 import {useTranslations} from 'use-intl';
 import {EditProfileDialog} from '@/app/edit/dialog';
@@ -147,42 +151,39 @@ export default function Home() {
         void navigate('/sign-up');
     };
 
-    const userQuery = useQuery({
+    const userQuery = useQuery<UserDetails, NetworkError>({
         queryKey: ['userDetails'],
-        queryFn: () => backend.getUserDetails(),
+        queryFn: () => backend.getUserDetails().then(unwrap),
         enabled: session.status === 'authed',
     });
 
-    const networkQuery = useQuery({
+    const networkQuery = useQuery<NetworkDetailsResponse, NetworkError>({
         queryKey: ['networkDetails', blockingQR],
-        queryFn: () => backend.getNetworkDetails(),
+        queryFn: () => backend.getNetworkDetails().then(unwrap),
         enabled: session.status === 'authed',
     });
-
-    const userResult = userQuery.data ?? null;
-    const networkResult = networkQuery.data ?? null;
 
     useEffect(() => {
-        if (userResult?.ok) {
-            appRef.current.setUserDetails(userResult.data);
+        if (userQuery.data) {
+            appRef.current.setUserDetails(userQuery.data);
         }
-    }, [appRef, userResult]);
+    }, [appRef, userQuery.data]);
 
-    const hasResultError =
-        (userResult && !userResult.ok) || (networkResult && !networkResult.ok);
+    const isLoadingError =
+        (userQuery.isError && userQuery.data === undefined) ||
+        (networkQuery.isError && networkQuery.data === undefined);
 
-    const errorMessage =
-        userResult && !userResult.ok
-            ? formatNetworkError(userResult.error)
-            : networkResult && !networkResult.ok
-              ? formatNetworkError(networkResult.error)
-              : null;
+    const errorMessage = userQuery.error
+        ? formatNetworkError(userQuery.error)
+        : networkQuery.error
+          ? formatNetworkError(networkQuery.error)
+          : null;
 
     const isLoading = session.status === 'loading' || userQuery.isLoading;
-    const isError = userQuery.isError || hasResultError;
+    const isError = isLoadingError;
 
     const user = app.userDetails;
-    const friends = networkResult?.ok ? networkResult.data.friends : [];
+    const friends = networkQuery.data?.friends ?? [];
 
     let content;
 

--- a/src/app/qr-code-dialog.tsx
+++ b/src/app/qr-code-dialog.tsx
@@ -8,6 +8,8 @@ import {Copy, Loader2, RotateCcw} from 'lucide-react';
 import QRCode from 'react-qr-code';
 import {toast} from 'sonner';
 import {useTranslations} from 'use-intl';
+import {unwrap} from '@/network/result';
+import {NetworkError} from '@/network/errors';
 
 export interface QrCodeDialogProps {
     open: boolean;
@@ -20,15 +22,15 @@ export function QrCodeDialog({open, setOpen}: QrCodeDialogProps) {
     const backend = useBackend();
     const user = useAppContext().userDetails;
 
-    const inviteQuery = useQuery({
+    const inviteQuery = useQuery<string, NetworkError>({
         queryKey: ['inviteToken'],
-        queryFn: () => backend.generateFriendInvitationToken(),
+        queryFn: () => backend.generateFriendInvitationToken().then(unwrap),
         enabled: open,
     });
 
     const url =
-        user?.id && inviteQuery.data?.ok
-            ? createFriendInviteLink(user.id, inviteQuery.data.data)
+        user?.id && inviteQuery.data
+            ? createFriendInviteLink(user.id, inviteQuery.data)
             : null;
 
     async function forceRefresh() {

--- a/src/app/user/[id]/page.tsx
+++ b/src/app/user/[id]/page.tsx
@@ -21,6 +21,7 @@ import {
 } from '@/components/ui/dropdown-menu';
 import {ConfirmationDialog} from '@/components/confirmation-dialog';
 import {StyledAvatar} from '@/components/styled-avatar';
+import {unwrap} from '@/network/result';
 
 interface ProfileDropdownProps {
     onRemoveFriend: () => void;
@@ -177,14 +178,17 @@ export default function UserPage() {
     const userQuery = useQuery({
         queryKey: ['user', id],
         queryFn: async () => {
-            if (!id)
-                return Promise.reject(new Error('Id is null or undefined'));
+            if (!id) throw new Error('Id is null or undefined');
+
             const idNum = parseInt(id);
             const userPair = await userAccessHashes.service.get(idNum);
-            const accessHash = userPair.accessHash;
-            return backend.getUserDetailsById(parseInt(id), accessHash);
+            return unwrap(
+                await backend.getUserDetailsById(idNum, userPair.accessHash),
+            );
         },
     });
+
+    const isLoadingError = userQuery.isError && userQuery.data === undefined;
 
     let content;
 
@@ -194,18 +198,18 @@ export default function UserPage() {
                 <Loader2 className="h-10 w-10 animate-spin text-muted-foreground" />
             </div>
         );
-    } else if (userQuery.isError || !userQuery.data?.ok) {
+    } else if (isLoadingError) {
         content = (
             <div className="flex flex-col h-[50vh] gap-4 w-full items-center justify-center">
                 <Activity className="h-10 w-10 animate-pulse text-foreground/80" />
                 <h3>{userQuery.error?.message ?? t('unknown_error')}</h3>
             </div>
         );
-    } else {
+    } else if (userQuery.data) {
         content = (
             <div className="flex flex-col gap-2 pb-12">
                 <ProfileHeader
-                    userDetails={userQuery.data.data}
+                    userDetails={userQuery.data}
                     onRemoveFriend={declineFriend}
                 />
                 <Separator />
@@ -213,7 +217,7 @@ export default function UserPage() {
                 <div className="flex flex-col md:flex-row gap-8">
                     <div className="flex-1 flex flex-col gap-8 p-8 min-w-0">
                         <InterestsBlock
-                            interests={userQuery.data.data?.interests ?? []}
+                            interests={userQuery.data?.interests ?? []}
                         />
                     </div>
                 </div>

--- a/src/components/query-provider.tsx
+++ b/src/components/query-provider.tsx
@@ -6,6 +6,7 @@ import {
 } from '@tanstack/react-query';
 import {useEffect, useRef, useState} from 'react';
 import {useSession} from '@/components/session-provider';
+import {isRetryableNetworkError} from '@/network/errors';
 
 export function QueryProvider({children}: {children: React.ReactNode}) {
     const session = useSession();
@@ -21,7 +22,8 @@ export function QueryProvider({children}: {children: React.ReactNode}) {
             new QueryClient({
                 defaultOptions: {
                     queries: {
-                        retry: 3,
+                        retry: (failureCount, error) =>
+                            isRetryableNetworkError(error) && failureCount < 3,
                         retryDelay: attempt =>
                             Math.min(1_000 * 2 ** attempt, 10_000),
                         refetchOnWindowFocus: true,

--- a/src/network/errors.ts
+++ b/src/network/errors.ts
@@ -4,3 +4,17 @@ export type NetworkError =
     | {type: 'network'; message: string}
     | {type: 'unauthorized'; status: number}
     | {type: 'parse'; message: string};
+
+export function isNetworkError(value: unknown): value is NetworkError {
+    if (typeof value !== 'object' || value === null || !('type' in value)) {
+        return false;
+    }
+
+    return ['unknown', 'status', 'network', 'unauthorized', 'parse'].includes(
+        value.type as string,
+    );
+}
+
+export function isRetryableNetworkError(value: unknown): boolean {
+    return isNetworkError(value) && value.type === 'network';
+}

--- a/src/network/friendly-client.ts
+++ b/src/network/friendly-client.ts
@@ -74,6 +74,7 @@ export class FriendlyClientImpl implements FriendlyClient {
         this.baseUrl = baseUrl;
         this.client = axios.create({
             baseURL: this.baseUrl,
+            timeout: 15_000,
             headers: {
                 'Content-Type': 'application/json',
             },

--- a/src/network/result.ts
+++ b/src/network/result.ts
@@ -3,6 +3,11 @@ export type Result<T, E> = {ok: true; data: T} | {ok: false; error: E};
 export const ok = <T>(data: T): Result<T, never> => ({ok: true, data});
 export const err = <E>(error: E): Result<never, E> => ({ok: false, error});
 
+export function unwrap<T, E extends object>(result: Result<T, E>): T {
+    if (!result.ok) throw Object.assign(new Error(), result.error);
+    return result.data;
+}
+
 export function match<T, E, U>(
     r: Result<T, E>,
     branches: {


### PR DESCRIPTION
queryFn resolved a Result instead of rejecting, so React Query treated network failures as successful fetches — no retries, and cached data got overwritten with the error. This caused the "Network Error" screen on every app resume from background.

- unwrap() throws on a failed Result instead of returning it as data
- queries only show the error screen when there's no cached data yet
- retry only on transient network errors, not 401/status
- add axios timeout so hung requests fail fast enough to retry

Fixes #263