### PR TITLE
fix(localization): fall back to English for missing translations

### DIFF
--- a/src/components/intl-provider.tsx
+++ b/src/components/intl-provider.tsx
@@ -1,15 +1,37 @@
 import {IntlProvider as UseIntlProvider} from 'use-intl';
 import {useEffect, useState} from 'react';
-import type en from '../messages/en.json';
+import en from '../messages/en.json';
 
 type Messages = typeof en;
 
-const loaders: Record<string, () => Promise<{default: Messages}>> = {
+type PartialMessages<T> = {
+    [K in keyof T]?: T[K] extends string ? string : PartialMessages<T[K]>;
+};
+
+const loaders: Record<string, () => Promise<{default: PartialMessages<Messages>}>> = {
     en: () => import('../messages/en.json'),
     ru: () => import('../messages/ru.json'),
 };
 
 const fallbackLocale = 'en';
+
+function mergeMessages<T>(base: T, override: PartialMessages<T> | undefined): T {
+    if (!override) return base;
+
+    const merged = {...base};
+
+    for (const key of Object.keys(base as object) as (keyof T)[]) {
+        const value = override[key];
+        if (value === undefined) continue;
+
+        merged[key] =
+            typeof base[key] === 'object' && base[key] !== null
+                ? mergeMessages(base[key], value as PartialMessages<T[keyof T]>)
+                : (value as T[keyof T]);
+    }
+
+    return merged;
+}
 
 export default function IntlProvider({children}: {children: React.ReactNode}) {
     const [messages, setMessages] = useState<Messages | null>(null);
@@ -21,15 +43,12 @@ export default function IntlProvider({children}: {children: React.ReactNode}) {
 
         loaders[loc]()
             .then(mod => {
-                setMessages(mod.default);
+                setMessages(mergeMessages(en, mod.default));
                 setLocale(loc);
-                console.log(`Loaded locale ${loc}`);
             })
             .catch(() => {
-                void loaders[fallbackLocale]().then(mod => {
-                    setMessages(mod.default);
-                    setLocale(fallbackLocale);
-                });
+                setMessages(en);
+                setLocale(fallbackLocale);
             });
     }, []);
 


### PR DESCRIPTION
Non-default locale files were typed as `typeof en`, forcing every locale to be structurally identical to en.json. A single missing key (menu.feed in ru.json) failed the whole module and broke the build.

Type non-default locales as a recursive partial of the English messages and deep-merge the loaded locale over `en` before passing it to the provider, so absent keys render English instead of nothing.

Closes #293