### PR TITLE
fix(notifications): check if notifications api is supported in user's browser to prevent empty page on refresh on mobile

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -121,7 +121,7 @@ const start = performance.now();
 
 await authService.initialize(app);
 initializeBackendService(app);
-Notifications.main(app);
+void Notifications.main(app);
 
 console.log(`Initialization finished in ${performance.now() - start}`);
 

--- a/src/notifications.ts
+++ b/src/notifications.ts
@@ -5,6 +5,7 @@ import {
     getToken,
     onMessage,
     MessagePayload,
+    isSupported,
 } from 'firebase/messaging';
 
 // Erm... Actually, these are not private
@@ -18,12 +19,16 @@ const firebaseConfig = {
     measurementId: 'G-R5K08P6EBR',
 };
 
-const app = initializeApp(firebaseConfig);
-const messaging = getMessaging(app);
+const firebaseApp = initializeApp(firebaseConfig);
 
 const swiped = Number(localStorage.getItem('feed-swipes') ?? '0');
 
-export function main(app: AppContext) {
+export async function main(app: AppContext) {
+    if (!(await isSupported())) return;
+
+    const messaging = getMessaging(firebaseApp);
+    onMessage(messaging, message => void postMessage(message));
+
     if (
         swiped > 20 ||
         localStorage.getItem('request-notifications') === 'true'
@@ -103,4 +108,3 @@ async function postMessage(payload: MessagePayload) {
     );
     registration?.active?.postMessage(payload);
 }
-onMessage(messaging, message => void postMessage(message));


### PR DESCRIPTION
The problem was that IOS webkit only allows push notifications for PWAs and not for normal web apps.
This fix is related to #233. The problem is that the original report was made for android firefox, and I cannot guarantee that these changes also fix the cause of the original issue

Demo with the made changes:
https://github.com/user-attachments/assets/8e30ee51-a136-4ca3-926d-b71c9018e65b